### PR TITLE
Fix https://github.com/3dtof/voxelsdk/issues/93

### DIFF
--- a/Voxel/PointCloudTransform.cpp
+++ b/Voxel/PointCloudTransform.cpp
@@ -19,7 +19,7 @@ namespace Voxel
 
 Point &PointCloudTransform::getDirection(int row, int col)
 {
-  return directions[col * width + row];
+  return directions[row * width + col];
 }
 
 PointCloudTransform::PointCloudTransform(uint32_t left, uint32_t top, uint32_t width, uint32_t height, 


### PR DESCRIPTION
As reported in issue #93, the vector/array lookup in the getDirection function does a wrong lookup, as row and col were confused in the formula. This can cause wrong projections or segmentation faults.
