### PR TITLE
Bug fixes for handling multiple cameras

### DIFF
--- a/TI3DToF/boards/TintinCDK/TintinCDKCameraUVC.h
+++ b/TI3DToF/boards/TintinCDK/TintinCDKCameraUVC.h
@@ -7,8 +7,9 @@
 #ifndef VOXEL_TI_TINTINCDKCAMERAUVC_H
 #define VOXEL_TI_TINTINCDKCAMERAUVC_H
 
-#include <TintinCDKCamera.h>
+#include <ToFTintinCamera.h>
 #include <Downloader.h>
+#include <TintinCDKCameraCommon.h>
 #define TINTIN_CDK_VENDOR_ID 0x0451U
 #define TINTIN_CDK_PRODUCT_UVC 0x9106U
 
@@ -29,7 +30,7 @@ namespace Voxel
 namespace TI
 {
 
-class TintinCDKCameraUVC: public TintinCDKCamera
+class TintinCDKCameraUVC: public ToFTintinCamera
 {
 protected:
   Ptr<Downloader> _downloader;
@@ -37,9 +38,14 @@ protected:
 
   bool _init();
 
+  virtual bool _getFieldOfView(float &fovHalfAngle) const;
   virtual bool _getSupportedVideoModes(Vector<SupportedVideoMode> &supportedVideoModes) const;
   virtual bool _setStreamerFrameSize(const FrameSize &s);
+
   virtual bool _getMaximumVideoMode(VideoMode &videoMode) const;
+  virtual bool _getMaximumFrameRate(FrameRate& frameRate, const FrameSize& forFrameSize) const;
+
+  virtual bool _initStartParams();
 
 public:
   TintinCDKCameraUVC(DevicePtr device);

--- a/Voxel/USBIO.cpp
+++ b/Voxel/USBIO.cpp
@@ -107,24 +107,34 @@ USBIO::USBIOPrivate::USBIOPrivate(DevicePtr device): device(device), handle(0), 
     return;
   }
 #elif defined(WINDOWS)
-  String devicePath = sys.getDeviceNode(d);
   
-  if (!devicePath.size())
+  handle = new CCyUSBDevice();
+  int numDevices = handle->DeviceCount();
+  int vid, pid;
+  wchar_t *serialNumber; //Return type of CCyUSB.SerialNumber is wchar, need to compare it with String
+  String serialNo, deviceSerialNumber;
+  int dev = 0;
+  do
   {
-    logger(LOG_ERROR) << "USBIO: Could not get device path for '" << d.id() << "'" << std::endl;
-    return;
-  }
+    handle->Open(dev);
+    vid = handle->VendorID;
+    pid = handle->ProductID;
+    serialNumber = handle->SerialNumber;
+    std::wstring sno(serialNumber);
+    String s(sno.begin(), sno.end()); //Converting wide string to string
+    serialNo = s;
+    deviceSerialNumber = d.serialNumber();
+    dev++;
+  } while((dev<numDevices) && (vid == d.vendorID()) && (pid == d.productID()) && (serialNo == deviceSerialNumber));
   
-  deviceHandle = CreateFile(devicePath.c_str(), GENERIC_WRITE | GENERIC_READ, FILE_SHARE_WRITE | FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, NULL);
-  
-  if (deviceHandle == INVALID_HANDLE_VALUE)
+  if (dev >=  numDevices && (vid != d.vendorID()) && (pid != d.productID()) && (serialNo != deviceSerialNumber))
   {
-    logger(LOG_ERROR) << "USBIO: Failed to open device path '" << devicePath << "' for device '" << d.id() << "'" << std::endl;
-    return;
+    logger(LOG_ERROR) << "USBIO: Failed to open device with ID'" << d.id() << "'" << std::endl;
+	handle->Close();
+	return;
   }
-  
-  handle = Ptr<CCyUSBDevice>(new CCyUSBDevice(deviceHandle));
-  
+
+
   if(handle->IsOpen())
   {
     _initialized = true;


### PR DESCRIPTION
On connecting multiple Tintin cameras, if one of the TintinCDKs was a bulk and one was a UVC, the UVC camera didn't stream. Fixed the bug with the first commit

For more than one camera, selecting any of the cameras started the stream for only one of them. Fixed the bug with changes in USBIO.cpp 