### PR TITLE
Bug fixes for handling multiple cameras

### DIFF
--- a/TI3DToF/boards/TintinCDK/TintinCDKCameraUVC.h
+++ b/TI3DToF/boards/TintinCDK/TintinCDKCameraUVC.h
@@ -7,8 +7,9 @@
 #ifndef VOXEL_TI_TINTINCDKCAMERAUVC_H
 #define VOXEL_TI_TINTINCDKCAMERAUVC_H
 
-#include <TintinCDKCamera.h>
+#include <ToFTintinCamera.h>
 #include <Downloader.h>
+#include <TintinCDKCameraCommon.h>
 #define TINTIN_CDK_VENDOR_ID 0x0451U
 #define TINTIN_CDK_PRODUCT_UVC 0x9106U
 
@@ -29,7 +30,7 @@ namespace Voxel
 namespace TI
 {
 
-class TintinCDKCameraUVC: public TintinCDKCamera
+class TintinCDKCameraUVC: public ToFTintinCamera
 {
 protected:
   Ptr<Downloader> _downloader;
@@ -37,9 +38,14 @@ protected:
 
   bool _init();
 
+  virtual bool _getFieldOfView(float &fovHalfAngle) const;
   virtual bool _getSupportedVideoModes(Vector<SupportedVideoMode> &supportedVideoModes) const;
   virtual bool _setStreamerFrameSize(const FrameSize &s);
+
   virtual bool _getMaximumVideoMode(VideoMode &videoMode) const;
+  virtual bool _getMaximumFrameRate(FrameRate& frameRate, const FrameSize& forFrameSize) const;
+
+  virtual bool _initStartParams();
 
 public:
   TintinCDKCameraUVC(DevicePtr device);


### PR DESCRIPTION
On connecting multiple Tintin cameras, if one of the TintinCDKs was a bulk and one was a UVC, the UVC camera didn't stream. Fixed the bug with the first commit

For more than one camera, selecting any of the cameras started the stream for only one of them. Fixed the bug with changes in USBIO.cpp