### PR TITLE
ToFCamera: Added a parameter to enable/disable per-pixel offsets

### DIFF
--- a/TI3DToF/ToFCamera.h
+++ b/TI3DToF/ToFCamera.h
@@ -93,6 +93,8 @@
 #define DISABLE_TEMP_CORR "disable_temp_corr"
 #define CALIB_PREC "calib_prec"
 
+#define DISABLE_PIXEL_OFFSETS "disable_per_pixel_offsets"
+
 #define ToF_FRAME_TYPE "output_mode"
 #define SOFTWARE_RESET "software_reset"
 
@@ -163,7 +165,7 @@ protected:
   virtual bool _saveCurrentProfileID(const int id);
   
   virtual bool _reset();
-  
+
   Ptr<ToFFrameGenerator> _tofFrameGenerator;
   
 public:

--- a/TI3DToF/ToFFrameGenerator.h
+++ b/TI3DToF/ToFFrameGenerator.h
@@ -23,6 +23,7 @@ class TI3DTOF_EXPORT ToFFrameGenerator: public FrameGenerator
   
   bool _dealiased16BitMode;
   int _dealiasedPhaseMaskInPhaseOffset, _dealiasedPhaseMask;
+  bool _disablePhaseOffsets;
   
   RegionOfInterest _roi;
   FrameSize _maxFrameSize, _frameSize, _size;
@@ -70,7 +71,7 @@ public:
                      const String &crossTalkCoefficients, ToFFrameType type, 
                      uint32_t quadCount,
                      bool dealiased16BitMode,
-                     int dealiasedPhaseMask);
+                     int dealiasedPhaseMask, bool phaseOffsetsDisable);
   
   virtual ~ToFFrameGenerator() {}
 };


### PR DESCRIPTION
Added a parameter to disable the per pixel offsets without creating a new profile.
Need to stop and start the camera again for the changes to take effect.